### PR TITLE
Refactor request handling and streamline API payload extraction

### DIFF
--- a/src/create_request.js
+++ b/src/create_request.js
@@ -288,6 +288,18 @@ const create_batch_jsonl = (requests) => {
 };
 
 /**
+ * Extracts only the API payload fields from validated data
+ * Excludes internal fields like provider, apiKey, batch
+ * @param {Object} validatedData - The validated input data
+ * @returns {Object} Clean API payload
+ */
+const extract_api_payload = (validatedData) => {
+  // Extract only the fields that should be sent to the API
+  const { provider, apiKey, batch, ...apiPayload } = validatedData;
+  return apiPayload;
+};
+
+/**
  * Creates an axios request configuration from a Zod schema and input data
  * @param {z.ZodSchema} schema - The Zod schema to validate input against
  * @param {Object} data - The input data to validate and convert
@@ -342,7 +354,7 @@ const create_request = (schema, data, options = {}) => {
   return {
     method: options.method || 'POST',
     url: options.url || get_default_url(validatedData.provider),
-    data: validatedData,
+    data: extract_api_payload(validatedData),
     headers: {
       ...create_provider_headers(validatedData),
       ...options.headers // Allow overriding provider headers
@@ -367,5 +379,6 @@ module.exports = {
   create_provider_headers,
   get_default_url,
   create_batch_request,
-  create_batch_jsonl
+  create_batch_jsonl,
+  extract_api_payload
 };

--- a/src/create_request.test.js
+++ b/src/create_request.test.js
@@ -2,8 +2,8 @@ const { z } = require('zod');
 const { create_request } = require('./create_request');
 const { llm_input_schema } = require('./llm_schema');
 
-// ✅ REUSABLE TEST DATA - No more duplication!
-const baseTestData = {
+// Base API payload (what gets sent to APIs)
+const basePayload = {
   model: 'gpt-4',
   messages: [{ role: 'user', content: 'Hello, how are you?' }],
   maxTokens: 1000,
@@ -11,69 +11,60 @@ const baseTestData = {
   stream: false
 };
 
-const createProviderData = (provider, apiKey = 'test-key-123') => ({
-  ...baseTestData,
-  provider,
-  ...(apiKey && { apiKey })
-});
-
-// ✅ REUSABLE BATCH TEST DATA
-const createBatchData = (provider, apiKey, batchConfig = {}) => ({
-  ...createProviderData(provider, apiKey),
-  batch: {
-    enabled: true,
-    ...batchConfig
-  }
-});
+// Base payload with API key (what we pass to create_request)
+const baseWithApiKey = {
+  ...basePayload,
+  apiKey: 'test-key-123'
+};
 
 describe('create_request', () => {
   describe('should convert universal schema to axios request for different providers', () => {
     it('should create OpenAI-compatible request', () => {
-      const inputData = createProviderData('openai', 'sk-test123');
-
-      const requestConfig = create_request(llm_input_schema, inputData);
+      const requestConfig = create_request(llm_input_schema, { ...baseWithApiKey, provider: 'openai' });
 
       expect(requestConfig).toEqual({
         method: 'POST',
         url: 'https://api.openai.com/v1/chat/completions',
-        data: inputData,
+        data: basePayload,
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${inputData.apiKey}`
+          'Authorization': 'Bearer test-key-123'
         }
       });
     });
 
     it('should create Anthropic-compatible request', () => {
-      const inputData = createProviderData('anthropic', 'sk-ant-test123');
-      inputData.model = 'claude-3-sonnet-20240229';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
+      const requestConfig = create_request(llm_input_schema, { 
+        ...baseWithApiKey, 
+        provider: 'anthropic',
+        model: 'claude-3-sonnet-20240229'
+      });
 
       expect(requestConfig).toEqual({
         method: 'POST',
         url: 'https://api.anthropic.com/v1/messages',
-        data: inputData,
+        data: {
+          ...basePayload,
+          model: 'claude-3-sonnet-20240229'
+        },
         headers: {
           'Content-Type': 'application/json',
-          'x-api-key': inputData.apiKey,
+          'x-api-key': 'test-key-123',
           'anthropic-version': '2025-05-22'
         }
       });
     });
 
     it('should create GitHub Models-compatible request (without API key)', () => {
-      const inputData = createProviderData('gh-models', null);
-      inputData.model = 'gpt-4o';
-      inputData.maxTokens = 500;
-      inputData.temperature = 0.3;
-
-      const requestConfig = create_request(llm_input_schema, inputData);
+      const requestConfig = create_request(llm_input_schema, {
+        ...basePayload,
+        provider: 'gh-models'
+      });
 
       expect(requestConfig).toEqual({
         method: 'POST',
         url: 'https://models.inference.ai.azure.com/chat/completions',
-        data: inputData,
+        data: basePayload,
         headers: {
           'Content-Type': 'application/json'
         }
@@ -81,53 +72,60 @@ describe('create_request', () => {
     });
 
     it('should create Hugging Face-compatible request (with API key)', () => {
-      const inputData = createProviderData('huggingface', 'hf_test123');
-      inputData.model = 'microsoft/DialoGPT-medium';
-      inputData.maxTokens = 500;
-
-      const requestConfig = create_request(llm_input_schema, inputData);
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'huggingface'
+      });
 
       expect(requestConfig).toEqual({
         method: 'POST',
         url: 'https://api-inference.huggingface.co/models',
-        data: inputData,
+        data: basePayload,
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${inputData.apiKey}`
+          'Authorization': 'Bearer test-key-123'
         }
       });
     });
 
     it('should create DeepSeek-compatible request', () => {
-      const inputData = createProviderData('deepseek', 'sk-deepseek-test123');
-      inputData.model = 'deepseek-chat';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'deepseek',
+        model: 'deepseek-chat'
+      });
 
       expect(requestConfig).toEqual({
         method: 'POST',
         url: 'https://api.deepseek.com/chat/completions',
-        data: inputData,
+        data: {
+          ...basePayload,
+          model: 'deepseek-chat'
+        },
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${inputData.apiKey}`
+          'Authorization': 'Bearer test-key-123'
         }
       });
     });
 
     it('should create Qwen-compatible request', () => {
-      const inputData = createProviderData('qwen', 'sk-qwen-test123');
-      inputData.model = 'qwen-plus';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'qwen',
+        model: 'qwen-plus'
+      });
 
       expect(requestConfig).toEqual({
         method: 'POST',
         url: 'https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions',
-        data: inputData,
+        data: {
+          ...basePayload,
+          model: 'qwen-plus'
+        },
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${inputData.apiKey}`
+          'Authorization': 'Bearer test-key-123'
         }
       });
     });
@@ -159,55 +157,59 @@ describe('create_request', () => {
     });
 
     it('should work without API key for providers that support it', () => {
-      const inputDataGitHub = createProviderData('gh-models', null);
-      inputDataGitHub.model = 'gpt-4o';
-
-      const inputDataOllama = createProviderData('ollama', null);
-      inputDataOllama.model = 'llama2';
-
       expect(() => {
-        create_request(llm_input_schema, inputDataGitHub);
+        create_request(llm_input_schema, {
+          ...basePayload,
+          provider: 'gh-models'
+        });
       }).not.toThrow();
 
       expect(() => {
-        create_request(llm_input_schema, inputDataOllama);
+        create_request(llm_input_schema, {
+          ...basePayload,
+          provider: 'ollama'
+        });
       }).not.toThrow();
     });
 
     it('should throw error for invalid message structure', () => {
-      const invalidData = createProviderData('openai');
-      invalidData.messages = [
-        { role: 'invalid-role', content: 'test' } // Invalid role
-      ];
-
       expect(() => {
-        create_request(llm_input_schema, invalidData);
+        create_request(llm_input_schema, {
+          ...baseWithApiKey,
+          provider: 'openai',
+          messages: [
+            { role: 'invalid-role', content: 'test' } // Invalid role
+          ]
+        });
       }).toThrow();
     });
 
     it('should throw error for invalid parameter ranges', () => {
-      const invalidData = createProviderData('openai');
-      invalidData.temperature = 3.0; // Invalid: above max of 2.0
-
       expect(() => {
-        create_request(llm_input_schema, invalidData);
+        create_request(llm_input_schema, {
+          ...baseWithApiKey,
+          provider: 'openai',
+          temperature: 3.0 // Invalid: above max of 2.0
+        });
       }).toThrow();
     });
   });
 
   describe('should handle optional parameters correctly', () => {
     it('should work with minimal required parameters', () => {
-      const minimalData = createProviderData('openai');
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'openai'
+      });
 
-      const requestConfig = create_request(llm_input_schema, minimalData);
-
-      expect(requestConfig.data).toEqual(minimalData);
+      expect(requestConfig.data).toEqual(basePayload);
       expect(requestConfig.method).toBe('POST'); // Default method
     });
 
     it('should include all optional parameters when provided', () => {
-      const fullData = createProviderData('openai');
-      Object.assign(fullData, {
+      const fullRequestData = {
+        ...baseWithApiKey,
+        provider: 'openai',
         messages: [
           { role: 'system', content: 'You are helpful.' },
           { role: 'user', content: 'Hello' }
@@ -234,99 +236,109 @@ describe('create_request', () => {
         }],
         responseFormat: { type: 'json_object' },
         seed: 42
-      });
+      };
 
-      const requestConfig = create_request(llm_input_schema, fullData);
+      const requestConfig = create_request(llm_input_schema, fullRequestData);
 
-      expect(requestConfig.data).toEqual(fullData);
+      // Extract expected payload (without provider and apiKey)
+      const { provider, apiKey, ...expectedFullPayload } = fullRequestData;
+      expect(requestConfig.data).toEqual(expectedFullPayload);
     });
   });
 
   describe('should handle different message types and tools', () => {
     it('should validate tool calling schema', () => {
-      const dataWithTools = createProviderData('openai');
-      dataWithTools.messages = [{ role: 'user', content: 'What is the weather?' }];
-      dataWithTools.tools = [{
-        type: 'function',
-        function: {
-          name: 'get_current_weather',
-          description: 'Get the current weather in a given location',
-          parameters: {
-            type: 'object',
-            properties: {
-              location: {
-                type: 'string',
-                description: 'The city and state, e.g. San Francisco, CA'
-              },
-              unit: {
-                type: 'string',
-                enum: ['celsius', 'fahrenheit']
-              }
-            },
-            required: ['location']
-          }
-        }
-      }];
-
       expect(() => {
-        create_request(llm_input_schema, dataWithTools);
+        create_request(llm_input_schema, {
+          ...baseWithApiKey,
+          provider: 'openai',
+          messages: [{ role: 'user', content: 'What is the weather?' }],
+          tools: [{
+            type: 'function',
+            function: {
+              name: 'get_current_weather',
+              description: 'Get the current weather in a given location',
+              parameters: {
+                type: 'object',
+                properties: {
+                  location: {
+                    type: 'string',
+                    description: 'The city and state, e.g. San Francisco, CA'
+                  },
+                  unit: {
+                    type: 'string',
+                    enum: ['celsius', 'fahrenheit']
+                  }
+                },
+                required: ['location']
+              }
+            }
+          }]
+        });
       }).not.toThrow();
     });
 
     it('should validate complex message thread', () => {
-      const conversationData = createProviderData('anthropic');
-      conversationData.model = 'claude-3-sonnet-20240229';
-      conversationData.messages = [
-        { role: 'system', content: 'You are a helpful coding assistant.' },
-        { role: 'user', content: 'Can you help me write a function?' },
-        { role: 'assistant', content: 'Of course! What kind of function do you need?' },
-        { role: 'user', content: 'A function to calculate fibonacci numbers.' }
-      ];
-      conversationData.maxTokens = 1500;
-      conversationData.temperature = 0.2;
-
       expect(() => {
-        create_request(llm_input_schema, conversationData);
+        create_request(llm_input_schema, {
+          ...baseWithApiKey,
+          provider: 'anthropic',
+          model: 'claude-3-sonnet-20240229',
+          messages: [
+            { role: 'system', content: 'You are a helpful coding assistant.' },
+            { role: 'user', content: 'Can you help me write a function?' },
+            { role: 'assistant', content: 'Of course! What kind of function do you need?' },
+            { role: 'user', content: 'A function to calculate fibonacci numbers.' }
+          ],
+          maxTokens: 1500,
+          temperature: 0.2
+        });
       }).not.toThrow();
     });
   });
 
   describe('should handle edge cases', () => {
     it('should handle empty optional arrays', () => {
-      const dataWithEmptyTools = createProviderData('openai');
-      dataWithEmptyTools.tools = []; // Empty array should be valid
-
       expect(() => {
-        create_request(llm_input_schema, dataWithEmptyTools);
+        create_request(llm_input_schema, {
+          ...baseWithApiKey,
+          provider: 'openai',
+          tools: [] // Empty array should be valid
+        });
       }).not.toThrow();
     });
 
     it('should handle string and array stop sequences', () => {
-      const dataWithStringStop = createProviderData('openai');
-      dataWithStringStop.stop = '\\n'; // Single string
-
-      const dataWithArrayStop = createProviderData('openai');
-      dataWithArrayStop.stop = ['\\n', 'END', 'STOP']; // Array of strings
-
       expect(() => {
-        create_request(llm_input_schema, dataWithStringStop);
+        create_request(llm_input_schema, {
+          ...baseWithApiKey,
+          provider: 'openai',
+          stop: '\\n' // Single string
+        });
       }).not.toThrow();
 
       expect(() => {
-        create_request(llm_input_schema, dataWithArrayStop);
+        create_request(llm_input_schema, {
+          ...baseWithApiKey,
+          provider: 'openai',
+          stop: ['\\n', 'END', 'STOP'] // Array of strings
+        });
       }).not.toThrow();
     });
   });
 
   describe('should handle batch processing for supported providers', () => {
     it('should create OpenAI batch request', () => {
-      const inputData = createBatchData('openai', 'sk-test123', {
-        inputFileId: 'file-abc123',
-        completionWindow: '24h',
-        metadata: { project: 'test' }
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'openai',
+        batch: {
+          enabled: true,
+          inputFileId: 'file-abc123',
+          completionWindow: '24h',
+          metadata: { project: 'test' }
+        }
       });
-
-      const requestConfig = create_request(llm_input_schema, inputData);
 
       expect(requestConfig).toEqual({
         method: 'POST',
@@ -339,19 +351,22 @@ describe('create_request', () => {
         },
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': 'Bearer sk-test123'
+          'Authorization': 'Bearer test-key-123'
         }
       });
     });
 
     it('should create Anthropic batch request', () => {
-      const inputData = createBatchData('anthropic', 'sk-ant-test123', {
-        inputFileId: 'file-xyz789',
-        completionWindow: '24h'
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'anthropic',
+        model: 'claude-3-sonnet-20240229',
+        batch: {
+          enabled: true,
+          inputFileId: 'file-xyz789',
+          completionWindow: '24h'
+        }
       });
-      inputData.model = 'claude-3-sonnet-20240229';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
 
       expect(requestConfig).toEqual({
         method: 'POST',
@@ -361,14 +376,15 @@ describe('create_request', () => {
             custom_id: expect.any(String),
             params: {
               model: 'claude-3-sonnet-20240229',
-              max_tokens: 1000, // From baseTestData
-              messages: [{ role: 'user', content: 'Hello, how are you?' }] // From baseTestData
+              max_tokens: 1000, // From basePayload
+              messages: [{ role: 'user', content: 'Hello, how are you?' }], // From basePayload
+              temperature: 0.7 // From basePayload
             }
           }]
         },
         headers: {
           'Content-Type': 'application/json',
-          'x-api-key': 'sk-ant-test123',
+          'x-api-key': 'test-key-123',
           'anthropic-version': '2025-05-22',
           'anthropic-beta': 'message-batches-2024-09-24'
         }
@@ -376,13 +392,16 @@ describe('create_request', () => {
     });
 
     it('should create Groq batch request', () => {
-      const inputData = createBatchData('groq', 'gsk_test123', {
-        inputFileId: 'file-groq123',
-        completionWindow: '24h'
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'groq',
+        model: 'mixtral-8x7b-32768',
+        batch: {
+          enabled: true,
+          inputFileId: 'file-groq123',
+          completionWindow: '24h'
+        }
       });
-      inputData.model = 'mixtral-8x7b-32768';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
 
       expect(requestConfig).toEqual({
         method: 'POST',
@@ -394,20 +413,24 @@ describe('create_request', () => {
         },
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': 'Bearer gsk_test123'
+          'Authorization': 'Bearer test-key-123'
         }
       });
     });
 
     it('should create SiliconFlow batch request', () => {
-      const inputData = createBatchData('siliconflow', 'sk-silicon123', {
-        inputFileId: 'file-silicon456',
-        completionWindow: '24h',
-        metadata: { environment: 'test' }
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'siliconflow',
+        model: 'Qwen/Qwen2-72B-Instruct',
+        apiKey: 'sk-silicon123',
+        batch: {
+          enabled: true,
+          inputFileId: 'file-silicon456',
+          completionWindow: '24h',
+          metadata: { environment: 'test' }
+        }
       });
-      inputData.model = 'Qwen/Qwen2-72B-Instruct';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
 
       expect(requestConfig).toEqual({
         method: 'POST',
@@ -426,12 +449,16 @@ describe('create_request', () => {
     });
 
     it('should create SiliconFlow batch request with minimal parameters', () => {
-      const inputData = createBatchData('siliconflow', 'sk-silicon789', {
-        inputFileId: 'file-silicon-minimal'
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'siliconflow',
+        model: 'Qwen/Qwen2-72B-Instruct',
+        apiKey: 'sk-silicon789',
+        batch: {
+          enabled: true,
+          inputFileId: 'file-silicon-minimal'
+        }
       });
-      inputData.model = 'Qwen/Qwen2-72B-Instruct';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
 
       expect(requestConfig).toEqual({
         method: 'POST',
@@ -449,10 +476,15 @@ describe('create_request', () => {
     });
 
     it('should create Together AI batch request', () => {
-      const inputData = createBatchData('together', 'together_test123');
-      inputData.model = 'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'together',
+        model: 'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
+        apiKey: 'together_test123',
+        batch: {
+          enabled: true
+        }
+      });
 
       expect(requestConfig).toEqual({
         method: 'POST',
@@ -461,8 +493,9 @@ describe('create_request', () => {
           requests: [{
             customId: expect.any(String),
             model: 'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
-            maxTokens: 1000, // From baseTestData
-            messages: [{ role: 'user', content: 'Hello, how are you?' }] // From baseTestData
+            maxTokens: 1000, // From basePayload
+            messages: [{ role: 'user', content: 'Hello, how are you?' }], // From basePayload
+            temperature: 0.7 // From basePayload
           }],
           batchSize: 10, // Default value
           timeout: 300    // Default value
@@ -475,13 +508,17 @@ describe('create_request', () => {
     });
 
     it('should create Together AI batch request with custom batch size and timeout', () => {
-      const inputData = createBatchData('together', 'together_test123', {
-        batchSize: 20,
-        timeout: 500
+      const requestConfig = create_request(llm_input_schema, {
+        ...baseWithApiKey,
+        provider: 'together',
+        model: 'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
+        apiKey: 'together_test123',
+        batch: {
+          enabled: true,
+          batchSize: 20,
+          timeout: 500
+        }
       });
-      inputData.model = 'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo';
-
-      const requestConfig = create_request(llm_input_schema, inputData);
 
       expect(requestConfig).toEqual({
         method: 'POST',
@@ -490,8 +527,9 @@ describe('create_request', () => {
           requests: [{
             customId: expect.any(String),
             model: 'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
-            maxTokens: 1000, // From baseTestData
-            messages: [{ role: 'user', content: 'Hello, how are you?' }] // From baseTestData
+            maxTokens: 1000, // From basePayload
+            messages: [{ role: 'user', content: 'Hello, how are you?' }], // From basePayload
+            temperature: 0.7 // From basePayload
           }],
           batchSize: 20,
           timeout: 500


### PR DESCRIPTION
Improve test data reuse in create_request tests and add a function to extract only the necessary API payload fields from validated data, enhancing request handling consistency.

## Summary by Sourcery

Centralise API payload extraction in a dedicated helper and streamline request handling by updating create_request implementation and refactoring tests to use shared fixtures and default behaviors.

New Features:
- Add extract_api_payload helper to isolate API payload fields from validated data

Enhancements:
- Refactor create_request to use extract_api_payload and omit internal fields in axios request
- Introduce shared basePayload and baseWithApiKey fixtures in tests to reduce duplication
- Remove redundant options and direct inputData in tests by relying on defaults and fixtures

Tests:
- Update create_request tests to use reusable payload fixtures and validate payload extraction
- Simplify test assertions to reflect streamlined data structure without provider, apiKey, or batch fields